### PR TITLE
Built anonymous reply button frontend

### DIFF
--- a/nodebb-theme-harmony/templates/partials/topic/reply-button.tpl
+++ b/nodebb-theme-harmony/templates/partials/topic/reply-button.tpl
@@ -6,6 +6,7 @@
 	</button>
 	<ul class="dropdown-menu dropdown-menu-end p-1 text-sm" role="menu">
 		<li><a class="dropdown-item rounded-1" href="#" component="topic/reply-as-topic" role="menuitem">[[topic:reply-as-topic]]</a></li>
+		<li><a class="dropdown-item rounded-1" href="#" component="topic/reply-as-topic" role="menuitem"> Reply anonymously </a></li>
 	</ul>
 </div>
 {{{ end }}}

--- a/public/language/en-US/topic.json
+++ b/public/language/en-US/topic.json
@@ -17,6 +17,7 @@
     "last-reply-time": "Last reply",
     "reply-options": "Reply options",
     "reply-as-topic": "Reply as topic",
+    "reply-anonymously": "Reply anonymously",
     "guest-login-reply": "Log in to reply",
     "login-to-view": "🔒 Log in to view",
     "edit": "Edit",

--- a/public/src/app.js
+++ b/public/src/app.js
@@ -297,6 +297,8 @@ if (document.readyState === 'loading') {
 		});
 	};
 
+	// write an anonymous version of newTopic(), which passes in Anonymous as the username and email!
+
 	app.newReply = async function (params) {
 		// backwards compatibilty for old signature (tid)
 		if (typeof params !== 'object') {

--- a/public/src/app.js
+++ b/public/src/app.js
@@ -279,7 +279,7 @@ if (document.readyState === 'loading') {
 	};
 
 	app.newTopic = function (params) {
-		console.log("new topic hook was fired!")
+		console.log('new topic hook was fired!');
 		// backwards compatibilty for old signature (cid, tags)
 		if (typeof params !== 'object') {
 			if (params) {

--- a/public/src/app.js
+++ b/public/src/app.js
@@ -279,6 +279,7 @@ if (document.readyState === 'loading') {
 	};
 
 	app.newTopic = function (params) {
+		console.log("new topic hook was fired!")
 		// backwards compatibilty for old signature (cid, tags)
 		if (typeof params !== 'object') {
 			if (params) {

--- a/public/src/client/topic/postTools.js
+++ b/public/src/client/topic/postTools.js
@@ -115,7 +115,8 @@ define('forum/topic/postTools', [
 			e.preventDefault();
 			onReplyClicked($(this), tid);
 		});
-
+		
+		// add a reply-anonymously version of this!
 		$('.topic').on('click', '[component="topic/reply-as-topic"]', function () {
 			translator.translate(`[[topic:link-back, ${ajaxify.data.titleRaw}, ${config.relative_path}/topic/${ajaxify.data.slug}]]`, function (body) {
 				hooks.fire('action:composer.topic.new', {

--- a/public/src/client/topic/postTools.js
+++ b/public/src/client/topic/postTools.js
@@ -117,7 +117,7 @@ define('forum/topic/postTools', [
 		});
 		// add a reply-anonymously version of this!
 		$('.topic').on('click', '[component="topic/reply-as-topic"]', function () {
-			console.log("Reply-on-topic was called!")
+			console.log('Reply-on-topic was called!');
 			translator.translate(`[[topic:link-back, ${ajaxify.data.titleRaw}, ${config.relative_path}/topic/${ajaxify.data.slug}]]`, function (body) {
 				hooks.fire('action:composer.topic.new', {
 					cid: ajaxify.data.cid,

--- a/public/src/client/topic/postTools.js
+++ b/public/src/client/topic/postTools.js
@@ -115,7 +115,6 @@ define('forum/topic/postTools', [
 			e.preventDefault();
 			onReplyClicked($(this), tid);
 		});
-		
 		// add a reply-anonymously version of this!
 		$('.topic').on('click', '[component="topic/reply-as-topic"]', function () {
 			translator.translate(`[[topic:link-back, ${ajaxify.data.titleRaw}, ${config.relative_path}/topic/${ajaxify.data.slug}]]`, function (body) {

--- a/public/src/client/topic/postTools.js
+++ b/public/src/client/topic/postTools.js
@@ -117,6 +117,7 @@ define('forum/topic/postTools', [
 		});
 		// add a reply-anonymously version of this!
 		$('.topic').on('click', '[component="topic/reply-as-topic"]', function () {
+			console.log("Reply-on-topic was called!")
 			translator.translate(`[[topic:link-back, ${ajaxify.data.titleRaw}, ${config.relative_path}/topic/${ajaxify.data.slug}]]`, function (body) {
 				hooks.fire('action:composer.topic.new', {
 					cid: ajaxify.data.cid,


### PR DESCRIPTION
To make this button, I first read documentation and then traced through the code with numerous log statements. Then, I analyzed the .tpl structure of the "Reply as Topic" button, and then modeled my "Reply Anonymously" button after that.

Specifically, within the file `reply_button.tpl`, I added
`<li><a class="dropdown-item rounded-1" href="#" component="topic/reply-as-topic" role="menuitem"> Reply anonymously </a></li>`, which adds a subbutton in the Reply button.

For the user, when opening up NodeBB, they can simply click the other options under the Reply button, and will see this "Reply as Anonymous" button popup:
<img width="1495" alt="Screenshot 2025-02-09 at 10 40 37 PM" src="https://github.com/user-attachments/assets/a8efb92e-c909-431a-a52a-0b2b99b8bb31" />


As far as testing, I made sure to run `npm run lint` and `npm run test` and confirmed that all code passes the styling guidelines set forth by the linter. Additionally, I had my teammate Savannah run and test my changes from her machine within my branch.

resolves #16 