### PR TITLE
Add reaction buttons to post toolbars

### DIFF
--- a/nodebb-theme-harmony/less/topic.less
+++ b/nodebb-theme-harmony/less/topic.less
@@ -1,0 +1,38 @@
+.topic-heart {
+    margin-left: 1rem;
+    
+    .heart {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        color: #666;
+        text-decoration: none;
+        padding: 0.5rem;
+        border-radius: 0.25rem;
+        transition: all 0.2s ease;
+
+        &:hover {
+            background: rgba(0,0,0,0.05);
+            text-decoration: none;
+        }
+
+        &.hearted {
+            color: #e91e63;
+            
+            .fa-heart {
+                animation: heart-burst 0.3s ease-out;
+            }
+        }
+
+        .heart-count {
+            font-size: 0.9em;
+            min-width: 20px;
+        }
+    }
+}
+
+@keyframes heart-burst {
+    0% { transform: scale(1); }
+    50% { transform: scale(1.3); }
+    100% { transform: scale(1); }
+} 

--- a/nodebb-theme-harmony/templates/partials/post_bar.tpl
+++ b/nodebb-theme-harmony/templates/partials/post_bar.tpl
@@ -20,6 +20,20 @@
 						<span component="topic/heart/count" class="heart-count text-danger fw-semibold">9</span>
 					</a>
 				</div>
+
+				<div component="topic/thumbsup" class="topic-thumbsup">
+					<a href="#" class="thumbsup btn-ghost-sm ff-secondary" data-tid="{tid}">
+						<i class="fa fa-thumbs-up text-primary"></i>
+						<span component="topic/thumbsup/count" class="thumbsup-count text-primary fw-semibold">19</span>
+					</a>
+				</div>
+
+				<div component="topic/thumbsdown" class="topic-thumbsdown">
+					<a href="#" class="thumbsdown btn-ghost-sm ff-secondary" data-tid="{tid}">
+						<i class="fa fa-thumbs-down text-primary"></i>
+						<span component="topic/thumbsdown/count" class="thumbsdown-count text-primary fw-semibold">2</span>
+					</a>
+				</div>
 				<!-- ENDIF loggedIn -->
 
 				{{{ if (!feeds:disableRSS && rssFeedUrl) }}}

--- a/nodebb-theme-harmony/templates/partials/post_bar.tpl
+++ b/nodebb-theme-harmony/templates/partials/post_bar.tpl
@@ -16,8 +16,8 @@
 				<!-- IF loggedIn -->
 				<div component="topic/heart" class="topic-heart">
 					<a href="#" class="heart btn-ghost-sm ff-secondary" data-tid="{tid}">
-						<i class="fa fa-heart"></i>
-						<span component="topic/heart/count" class="heart-count">0</span>
+						<i class="fa fa-heart text-danger"></i>
+						<span component="topic/heart/count" class="heart-count text-danger fw-semibold">9</span>
 					</a>
 				</div>
 				<!-- ENDIF loggedIn -->

--- a/nodebb-theme-harmony/templates/partials/post_bar.tpl
+++ b/nodebb-theme-harmony/templates/partials/post_bar.tpl
@@ -13,6 +13,15 @@
 				<!-- IMPORT partials/topic/sort.tpl -->
 				<!-- IMPORT partials/topic/tools.tpl -->
 
+				<!-- IF loggedIn -->
+				<div component="topic/heart" class="topic-heart">
+					<a href="#" class="heart btn-ghost-sm ff-secondary" data-tid="{tid}">
+						<i class="fa fa-heart"></i>
+						<span component="topic/heart/count" class="heart-count">0</span>
+					</a>
+				</div>
+				<!-- ENDIF loggedIn -->
+
 				{{{ if (!feeds:disableRSS && rssFeedUrl) }}}
 				<a class="btn-ghost-sm d-none d-lg-flex align-self-stretch" target="_blank" href="{rssFeedUrl}" title="[[global:rss-feed]]"><i class="fa fa-rss text-primary"></i></a>
 				{{{ end }}}

--- a/public/src/client/topic/threadTools.js
+++ b/public/src/client/topic/threadTools.js
@@ -403,16 +403,6 @@ define('forum/topic/threadTools', [
 		components.get('topic/ignoring/check').toggleClass('fa-check', state === 'ignore');
 	}
 
-	function updateHeartCount() {
-		const tid = ajaxify.data.tid;
-		socket.emit('topics.getHeartCount', tid, function (err, count) {
-			if (err) {
-				return app.alertError(err);
-			}
-			$('[component="topic/heart/count"]').text(count);
-		});
-	}
-
 	// Update the click handler to use the correct selector
 	$('[component="topic/heart"]').on('click', '.heart', function (e) {
 		e.preventDefault();

--- a/public/src/client/topic/threadTools.js
+++ b/public/src/client/topic/threadTools.js
@@ -403,6 +403,28 @@ define('forum/topic/threadTools', [
 		components.get('topic/ignoring/check').toggleClass('fa-check', state === 'ignore');
 	}
 
+	function updateHeartCount() {
+		const tid = ajaxify.data.tid;
+		socket.emit('topics.getHeartCount', tid, function (err, count) {
+			if (err) {
+				return app.alertError(err);
+			}
+			$('[component="topic/heart/count"]').text(count);
+		});
+	}
+
+	// Update the click handler to use the correct selector
+	$('[component="topic/heart"]').on('click', '.heart', function (e) {
+		e.preventDefault();
+		const tid = ajaxify.data.tid;
+		socket.emit('topics.toggleHeart', { tid: tid }, function (err, data) {
+			if (err) {
+				return app.alertError(err);
+			}
+			$('[component="topic/heart/count"]').text(data.count);
+		});
+		return false;
+	});
 
 	return ThreadTools;
 });

--- a/src/socket.io/topics.js
+++ b/src/socket.io/topics.js
@@ -19,7 +19,6 @@ require('./topics/tools')(SocketTopics);
 require('./topics/infinitescroll')(SocketTopics);
 require('./topics/tags')(SocketTopics);
 require('./topics/merge')(SocketTopics);
-require('./topics/heart')(SocketTopics);
 
 SocketTopics.postcount = async function (socket, tid) {
 	const canRead = await privileges.topics.can('topics:read', tid, socket.uid);

--- a/src/socket.io/topics.js
+++ b/src/socket.io/topics.js
@@ -19,6 +19,7 @@ require('./topics/tools')(SocketTopics);
 require('./topics/infinitescroll')(SocketTopics);
 require('./topics/tags')(SocketTopics);
 require('./topics/merge')(SocketTopics);
+require('./topics/heart')(SocketTopics);
 
 SocketTopics.postcount = async function (socket, tid) {
 	const canRead = await privileges.topics.can('topics:read', tid, socket.uid);
@@ -126,6 +127,18 @@ SocketTopics.getPostCountInTopic = async function (socket, tid) {
 		return 0;
 	}
 	return await db.sortedSetScore(`tid:${tid}:posters`, socket.uid);
+};
+
+SocketTopics.getHeartCount = async function (socket, tid) {
+	const count = await db.getObjectField(`topic:${tid}`, 'heartCount') || 0;
+	return parseInt(count, 10);
+};
+
+SocketTopics.toggleHeart = async function (socket, data) {
+	if (!socket.uid || !data.tid) {
+		throw new Error('[[error:invalid-data]]');
+	}
+	return await topics.toggleHeart(data.tid, socket.uid);
 };
 
 require('../promisify')(SocketTopics);

--- a/src/topics/create.js
+++ b/src/topics/create.js
@@ -149,7 +149,7 @@ module.exports = function (Topics) {
 
 		const [heartCount, isHearted] = await Promise.all([
 			db.getObjectField(`topic:${tid}`, 'heartCount'),
-			topics.isHearted(tid, uid)
+			topics.isHearted(tid, uid),
 		]);
 
 		topicData.heartCount = parseInt(heartCount, 10) || 0;

--- a/src/topics/create.js
+++ b/src/topics/create.js
@@ -147,13 +147,9 @@ module.exports = function (Topics) {
 			await Topics.delete(tid);
 		}
 
-		const [heartCount, isHearted] = await Promise.all([
-			db.getObjectField(`topic:${tid}`, 'heartCount'),
-			topics.isHearted(tid, uid),
-		]);
-
+		const heartCount = await db.getObjectField(`topic:${tid}`, 'heartCount');
 		topicData.heartCount = parseInt(heartCount, 10) || 0;
-		topicData.isHearted = isHearted;
+
 		topicData.privileges = await privileges.topics.get(tid, uid);
 
 		analytics.increment(['topics', `topics:byCid:${topicData.cid}`]);

--- a/src/topics/create.js
+++ b/src/topics/create.js
@@ -1,4 +1,3 @@
-
 'use strict';
 
 const _ = require('lodash');
@@ -147,6 +146,15 @@ module.exports = function (Topics) {
 		if (topicData.scheduled) {
 			await Topics.delete(tid);
 		}
+
+		const [heartCount, isHearted] = await Promise.all([
+			db.getObjectField(`topic:${tid}`, 'heartCount'),
+			topics.isHearted(tid, uid)
+		]);
+
+		topicData.heartCount = parseInt(heartCount, 10) || 0;
+		topicData.isHearted = isHearted;
+		topicData.privileges = await privileges.topics.get(tid, uid);
 
 		analytics.increment(['topics', `topics:byCid:${topicData.cid}`]);
 		plugins.hooks.fire('action:topic.post', { topic: topicData, post: postData, data: data });
@@ -318,4 +326,6 @@ module.exports = function (Topics) {
 			throw new Error('[[error:no-privileges]]');
 		}
 	}
+
+	require('./heart')(Topics);
 };

--- a/src/topics/heart.js
+++ b/src/topics/heart.js
@@ -1,8 +1,10 @@
 // socket.io/hearts.js
+
 'use strict';
 
 const privileges = require('../privileges');
 const db = require('../database');
+
 const SocketHearts = module.exports;
 
 /**
@@ -17,7 +19,7 @@ SocketHearts.heart = async function (socket, data) {
 	if (!socket.uid || !data || !data.pid) {
 		throw new Error('[[error:invalid-data]]');
 	}
-	const pid = data.pid;
+	const { pid } = data;
 	const key = `pid:${pid}:hearts`;
 
 	// Check whether the user already hearted this post.
@@ -46,7 +48,7 @@ module.exports = function (Topics) {
 		await privileges.categories.give(privs, 'registered-users');
 	};
 
-	Topics.toggleHeart = async function (tid, uid) {
+	Topics.toggleHeart = async function (tid) {
 		const key = `topic:${tid}`;
 		await db.incrementObjectField(key, 'heartCount');
 		const count = await db.getObjectField(key, 'heartCount');

--- a/src/topics/heart.js
+++ b/src/topics/heart.js
@@ -1,0 +1,59 @@
+// socket.io/hearts.js
+'use strict';
+
+const privileges = require('../privileges');
+const db = require('../database');
+const SocketHearts = module.exports;
+
+/**
+ * Toggle a heart on a given post.
+ *
+ * @param {object} socket - The socket of the connected user.
+ * @param {object} data - The data payload, expected to include data.pid.
+ * @returns {Promise<object>} - Resolves with an object { count, action }.
+ */
+SocketHearts.heart = async function (socket, data) {
+	// Make sure the user is logged in and we got a valid post id.
+	if (!socket.uid || !data || !data.pid) {
+		throw new Error('[[error:invalid-data]]');
+	}
+	const pid = data.pid;
+	const key = `pid:${pid}:hearts`;
+
+	// Check whether the user already hearted this post.
+	const hasHearted = await db.isSetMember(key, socket.uid);
+	let action;
+	if (hasHearted) {
+		// Remove the heart if it already exists (toggle off).
+		await db.setRemove(key, socket.uid);
+		action = 'removed';
+	} else {
+		// Otherwise add the heart.
+		await db.setAdd(key, socket.uid);
+		action = 'added';
+	}
+	// Get the new total heart count.
+	const count = await db.getSetCard(key);
+	return { count, action };
+};
+
+// Allow socket callbacks to return promises
+require('../promisify')(SocketHearts);
+
+module.exports = function (Topics) {
+	Topics.initializeHeartPrivileges = async function () {
+		const privs = ['topics:heart'];
+		await privileges.categories.give(privs, 'registered-users');
+	};
+
+	Topics.toggleHeart = async function (tid, uid) {
+		const key = `topic:${tid}`;
+		await db.incrementObjectField(key, 'heartCount');
+		const count = await db.getObjectField(key, 'heartCount');
+		return { count: parseInt(count, 10) || 0 };
+	};
+
+	Topics.isHearted = async function (tid, uid) {
+		return await db.isSetMember(`tid:${tid}:hearts`, uid);
+	};
+};


### PR DESCRIPTION
To make this button, I first read documentation and then traced through the code with numerous log statements. Then, I analyzed the .tpl structure of the various buttons within the toolbar, and then modeled my reaction button after those.

Specifically, within the file `post_bar.tpl,` I added div containers holding an emoji, and a placeholder count for how many users have clicked each one.

Additionally, I've added files such as `heart.js`, where I'll be adding the backend logic to keep a count of how many users have reacted to that specific reaction. I will then make a similar file for the other reactions.

As far as testing, I made sure to run npm run lint and npm run test and confirmed that all code passes the styling guidelines set forth by the linter. Additionally, I had my teammate Savannah run and test my changes from her machine within my branch.

For the user, when opening up any post, they should see three preset emoji reactions in the toolbar:
<img width="1489" alt="Screenshot 2025-02-09 at 10 58 32 PM" src="https://github.com/user-attachments/assets/c4628976-3381-44e3-a45e-89f1e59e6dea" />


resolves #20 