### PR TITLE
Added dropdown option on new topic button

### DIFF
--- a/nodebb-theme-harmony/templates/partials/topic-list-bar.tpl
+++ b/nodebb-theme-harmony/templates/partials/topic-list-bar.tpl
@@ -38,7 +38,31 @@
 			<div class="d-flex gap-1 align-items-center">
 				{{{ if template.category }}}
 					{{{ if privileges.topics:create }}}
-					<a href="{config.relative_path}/compose?cid={cid}" component="category/post" id="new_topic" class="btn btn-primary btn-sm text-nowrap" data-ajaxify="false" role="button">[[category:new-topic-button]]</a>
+					<div class="btn-group">
+						<!-- Main New Topic Button -->
+						<a href="{config.relative_path}/compose?cid={cid}" component="category/post" id="new_topic" class="btn btn-primary btn-sm text-nowrap" data-ajaxify="false" role="button">
+							[[category:new-topic-button]]
+						</a>
+
+						<!-- Dropdown Toggle Button -->
+						<button type="button" class="btn btn-primary btn-sm dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+							<span class="caret"></span>
+						</button>
+
+						<!-- Dropdown Menu -->
+						<ul class="dropdown-menu dropdown-menu-end p-1 text-sm" role="menu">
+							<li>
+								<a href="{config.relative_path}/compose?cid={cid}" component="category/post" id="new_topic" class="dropdown-item" data-ajaxify="false" role="button">
+									Regular Topic
+								</a>
+							</li>
+							<li>
+								<a href="{config.relative_path}/compose?cid={cid}" component="category/post" id="new_topic" class="dropdown-item" data-ajaxify="false" role="button">
+									Post Anonymously
+								</a>
+							</li>
+						</ul>
+					</div>
 					{{{ end }}}
 				{{{ else }}}
 					{{{ if canPost }}}


### PR DESCRIPTION
To implement these changes, I made changes in nodebb-theme-harmony/templates/partials/topic-list-bar.tpl. I analyzed the structure of the template file and added 
```html
<button type="button" class="btn btn-primary btn-sm dropdown-toggle" 
        data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
    <span class="caret"></span>
</button>
```
After this I added the two drop-down list items, and defaulted their actions to the same as the original button.

For the users, this is how the implemented changes would work.

For testing, I did the lint and test suite and ensured the code coverage remained high. As only frontend change was implemented, visual confirmation was sufficient.

<img width="1458" alt="Screenshot 2025-02-11 at 21 35 32" src="https://github.com/user-attachments/assets/09d4b380-3a3c-44c1-b0dc-48162f188b7b" />


resolves #7 
