### PR TITLE
Implemented endorse post backend + Fixed Anon Refresh 

### DIFF
--- a/nodebb-theme-harmony/templates/partials/posts_list_item.tpl
+++ b/nodebb-theme-harmony/templates/partials/posts_list_item.tpl
@@ -9,6 +9,7 @@
             <div class="post-author d-flex align-items-center gap-1">
                 <a class="lh-1 text-decoration-none" href="{config.relative_path}/user/{./user.userslug}">{buildAvatar(./user, "16px", true, "not-responsive")}</a>
                 <a class="lh-1 fw-semibold" href="{config.relative_path}/user/{./user.userslug}">{../user.displayname}</a>
+                <a> Test! </a>
             </div>
             <span class="timeago text-muted lh-1" title="{./timestampISO}"></span>
         </div>

--- a/nodebb-theme-harmony/templates/partials/topic/post.tpl
+++ b/nodebb-theme-harmony/templates/partials/topic/post.tpl
@@ -75,7 +75,11 @@
 			</div>
 			{{{ end }}}
 			<div class="d-flex align-items-center gap-1 flex-grow-1 justify-content-end">
-				<a> Test post</a>
+				<a> Flag ID: {posts.flagId}</a>
+				{{{ if posts.flag }}}
+					<a> Test post </a>
+				{{{ end }}}
+
 				<span class="bookmarked opacity-0 text-primary"><i class="fa fa-bookmark-o"></i></span>
 				<a href="{config.relative_path}/post/{./pid}" class="post-index text-muted d-none d-md-inline">#{increment(./index, "1")}</a>
 			</div>

--- a/nodebb-theme-harmony/templates/partials/topic/post.tpl
+++ b/nodebb-theme-harmony/templates/partials/topic/post.tpl
@@ -6,12 +6,18 @@
 </div>
 {{{ end }}}
 <div class="d-flex align-items-start gap-3">
+
+    
 	<div class="bg-body d-none d-sm-block rounded-circle" style="outline: 2px solid var(--bs-body-bg);">
 		<a class="d-inline-block position-relative text-decoration-none" href="{{{ if ./user.userslug }}}{config.relative_path}/user/{./user.userslug}{{{ else }}}#{{{ end }}}" aria-label="[[aria:user-avatar-for, {./user.username}]]">
+			{{{ if !posts.anonymous }}}
 			{buildAvatar(posts.user, "48px", true, "", "user/picture")}
 			<span component="user/status" class="position-absolute translate-middle-y border border-white border-2 rounded-circle status {posts.user.status}"><span class="visually-hidden">[[global:{posts.user.status}]]</span></span>
+		    {{{ end }}}
 		</a>
 	</div>
+	
+
 	<div class="post-container d-flex flex-grow-1 flex-column w-100" style="min-width:0;">
 		<div class="d-flex align-items-center gap-1 flex-wrap w-100 post-header mt-1" itemprop="author" itemscope itemtype="https://schema.org/Person">
 			
@@ -19,21 +25,23 @@
 
 			{{{ if ./user.userslug }}}<meta itemprop="url" content="{config.relative_path}/user/{./user.userslug}">{{{ end }}}
 
+            
 			<div class="bg-body d-sm-none">
 				<a class="d-inline-block position-relative text-decoration-none" href="{{{ if ./user.userslug }}}{config.relative_path}/user/{./user.userslug}{{{ else }}}#{{{ end }}}">
+					{{{ if !posts.anonymous }}}
 					{buildAvatar(posts.user, "20px", true, "", "user/picture")}
 					<span component="user/status" class="position-absolute translate-middle-y border border-white border-2 rounded-circle status {posts.user.status}"><span class="visually-hidden">[[global:{posts.user.status}]]</span></span>
+				    {{{ end }}}
 				</a>
 			</div>
+			
 
 			<!-- changes here -->
 
-			{{{if !posts.quickreplaycreator }}}
-			<a class="fw-bold text-nowrap" href="{{{ if ./user.userslug }}}{config.relative_path}/user/{./user.userslug}{{{ else }}}#{{{ end }}}" data-username="{posts.user.username}" data-uid="{posts.user.uid}">{posts.user.displayname}</a>
-
-			{{{ else }}}
-			<a class="fw-bold text-nowrap" href="{{{ if ./user.userslug }}}{config.relative_path}/user/{./user.userslug}{{{ else }}}#{{{ end }}}" data-username="{posts.user.username}" data-uid="{posts.user.uid}">{posts.quickreplaycreator}</a>
-
+			{{{ if posts.anonymous }}}
+			<span>ANONYMOUS</span>
+            {{{ else }}}
+            <a class="fw-bold text-nowrap" href="{{{ if ./user.userslug }}}{config.relative_path}/user/{./user.userslug}{{{ else }}}#{{{ end }}}" data-username="{posts.user.username}" data-uid="{posts.user.uid}">{posts.user.displayname}</a>
 			{{{ end }}}
 
 

--- a/nodebb-theme-harmony/templates/partials/topic/post.tpl
+++ b/nodebb-theme-harmony/templates/partials/topic/post.tpl
@@ -75,6 +75,7 @@
 			</div>
 			{{{ end }}}
 			<div class="d-flex align-items-center gap-1 flex-grow-1 justify-content-end">
+				<a> Test post</a>
 				<span class="bookmarked opacity-0 text-primary"><i class="fa fa-bookmark-o"></i></span>
 				<a href="{config.relative_path}/post/{./pid}" class="post-index text-muted d-none d-md-inline">#{increment(./index, "1")}</a>
 			</div>

--- a/public/language/en-GB/flags.json
+++ b/public/language/en-GB/flags.json
@@ -80,6 +80,7 @@
 
 	"modal-title": "Report Content",
 	"modal-body": "Please specify your reason for flagging %1 %2 for review. Alternatively, use one of the quick report buttons if applicable.",
+	"modal-reason-new": "Endorsed by Admins",
 	"modal-reason-spam": "Spam",
 	"modal-reason-offensive": "Offensive",
 	"modal-reason-other": "Other (specify below)",

--- a/public/language/en-US/flags.json
+++ b/public/language/en-US/flags.json
@@ -80,6 +80,7 @@
 
 	"modal-title": "Report Content",
 	"modal-body": "Please specify your reason for flagging %1 %2 for review. Alternatively, use one of the quick report buttons if applicable.",
+	"modal-reason-new": "Endorsed by Admins",
 	"modal-reason-spam": "Spam",
 	"modal-reason-offensive": "Offensive",
 	"modal-reason-other": "Other (specify below)",

--- a/src/views/modals/flag.tpl
+++ b/src/views/modals/flag.tpl
@@ -10,6 +10,12 @@
 					[[flags:modal-body, {type}, {id}]]
 				</p>
 				<div>
+                    <div class="radio mb-2">
+                       <label for="flag-reason-new">
+                           <input type="radio" name="flag-reason" id="flag-reason-new" value="[[flags:modal-reason-new]]">
+                           [[flags:modal-reason-new]]
+                       </label>
+                    </div>
 					<div class="radio mb-2">
 						<label for="flag-reason-spam">
 							<input type="radio" name="flag-reason" id="flag-reason-spam" value="[[flags:modal-reason-spam]]">


### PR DESCRIPTION
This new code fixes the bug that we have been working on with the anonymous refresh. the anonymous __ would show up but upon refresh, everything would just revert back to the default settings. there was likely a database overriding that was happening due to the cascading nature of the database. The change was made but not completely updated in all parts of the database. Changing to checking a boolean was better for comparisons. 

started implementing the backend for the endorse feature. Because of the headache caused by creating a new field in the database for the anonymous reply feature, I decided to find a work around. 

Utilizing the already existing field of "flags" that allows multiple values to be stored made our lives esaier. We had to add an extra drop down option for flagging called "Endorsed by Admin". After a post was flagged, it would be stored in the database under the flagged field with the specific "Endorsed by Admin" token. This way, We can access this and display it on the front end. 

To Do: 
Implement front end display of endorsed post on the top right of a post. 
- This would be done by searching in the Database for where the flagged item is equal to "Endorsed by Admin"(exact logic TBD, need to understanf DB better), then display this in the post.tpl file. 


resolves #