### PR TITLE
Add frontend badge for endorsed by staff

### DIFF
--- a/nodebb-theme-harmony/templates/partials/topic/post.tpl
+++ b/nodebb-theme-harmony/templates/partials/topic/post.tpl
@@ -75,11 +75,9 @@
 			</div>
 			{{{ end }}}
 			<div class="d-flex align-items-center gap-1 flex-grow-1 justify-content-end">
-				<a> Flag ID: {posts.flagId}</a>
-				{{{ if posts.flag }}}
-					<a> Test post </a>
+				{{{ if posts.endorsedByStaff }}}
+				<span class="badge bg-success">Endorsed by Staff</span>
 				{{{ end }}}
-
 				<span class="bookmarked opacity-0 text-primary"><i class="fa fa-bookmark-o"></i></span>
 				<a href="{config.relative_path}/post/{./pid}" class="post-index text-muted d-none d-md-inline">#{increment(./index, "1")}</a>
 			</div>

--- a/public/openapi/components/schemas/PostObject.yaml
+++ b/public/openapi/components/schemas/PostObject.yaml
@@ -22,6 +22,8 @@ PostObject:
       type: number
     votes:
       type: number
+    flagId:
+      type: number
     endorsedByStaff:
       type: boolean
       description: Indicates if the post has been endorsed by an admin

--- a/public/openapi/components/schemas/PostObject.yaml
+++ b/public/openapi/components/schemas/PostObject.yaml
@@ -24,6 +24,7 @@ PostObject:
       type: number
     flagId:
       type: number
+      nullable: true
     endorsedByStaff:
       type: boolean
       description: Indicates if the post has been endorsed by an admin

--- a/public/openapi/components/schemas/PostObject.yaml
+++ b/public/openapi/components/schemas/PostObject.yaml
@@ -25,6 +25,7 @@ PostObject:
     endorsedByStaff:
       type: boolean
       description: Indicates if the post has been endorsed by an admin
+      nullable: true
     timestampISO:
       type: string
       description: An ISO 8601 formatted date string (complementing `timestamp`)

--- a/public/openapi/components/schemas/PostObject.yaml
+++ b/public/openapi/components/schemas/PostObject.yaml
@@ -22,6 +22,9 @@ PostObject:
       type: number
     votes:
       type: number
+    endorsedByStaff:
+      type: boolean
+      description: Indicates if the post has been endorsed by an admin
     timestampISO:
       type: string
       description: An ISO 8601 formatted date string (complementing `timestamp`)

--- a/public/openapi/read/topic/topic_id.yaml
+++ b/public/openapi/read/topic/topic_id.yaml
@@ -264,9 +264,6 @@ get:
                           type: boolean
                         display_post_menu:
                           type: boolean
-                        flagId:
-                          type: number
-                          description: The flag identifier, if this particular post has been flagged before
                   events:
                     type: array
                     items:

--- a/public/openapi/read/topic/topic_id.yaml
+++ b/public/openapi/read/topic/topic_id.yaml
@@ -84,6 +84,7 @@ get:
                           type: number
                         flagId:
                           type: number
+                          nullable: true
                         endorsedByStaff:
                           type: boolean
                           description: Indicates if the post has been endorsed by an admin

--- a/public/openapi/read/topic/topic_id.yaml
+++ b/public/openapi/read/topic/topic_id.yaml
@@ -85,6 +85,7 @@ get:
                         endorsedByStaff:
                           type: boolean
                           description: Indicates if the post has been endorsed by an admin
+                          nullable: true
                         timestampISO:
                           type: string
                           description: An ISO 8601 formatted date string (complementing `timestamp`)

--- a/public/openapi/read/topic/topic_id.yaml
+++ b/public/openapi/read/topic/topic_id.yaml
@@ -82,6 +82,8 @@ get:
                           type: number
                         edited:
                           type: number
+                        flagId:
+                          type: number
                         endorsedByStaff:
                           type: boolean
                           description: Indicates if the post has been endorsed by an admin

--- a/public/openapi/read/topic/topic_id.yaml
+++ b/public/openapi/read/topic/topic_id.yaml
@@ -82,6 +82,9 @@ get:
                           type: number
                         edited:
                           type: number
+                        endorsedByStaff:
+                          type: boolean
+                          description: Indicates if the post has been endorsed by an admin
                         timestampISO:
                           type: string
                           description: An ISO 8601 formatted date string (complementing `timestamp`)

--- a/public/openapi/write/posts/pid.yaml
+++ b/public/openapi/write/posts/pid.yaml
@@ -41,6 +41,10 @@ get:
                     type: number
                   anonymous:
                     type: number
+                  endorsedByStaff:
+                    type: boolean
+                    description: Indicates if the post has been endorsed by an admin
+                    nullable: true
                   flagId:
                     type: number
                   deleted:

--- a/public/openapi/write/posts/pid.yaml
+++ b/public/openapi/write/posts/pid.yaml
@@ -74,6 +74,19 @@ get:
                     type: boolean
                   downvoted:
                     type: boolean
+                required:
+                  - pid
+                  - uid
+                  - tid
+                  - content
+                  - timestamp
+                  - upvotes
+                  - downvotes
+                  - votes
+                  - timestampISO
+                  - upvoted
+                  - downvoted
+                  - endorsedByStaff
 put:
   tags:
     - posts

--- a/public/openapi/write/posts/pid.yaml
+++ b/public/openapi/write/posts/pid.yaml
@@ -47,6 +47,7 @@ get:
                     nullable: true
                   flagId:
                     type: number
+                    nullable: true
                   deleted:
                     type: number
                   upvotes:

--- a/src/api/posts.js
+++ b/src/api/posts.js
@@ -40,9 +40,7 @@ postsAPI.get = async function (caller, data) {
 		const flags = require('../flags');
 		try {
 			const reports = await flags.getReports(post.flagId);
-			post.endorsedByStaff = reports.some(report => 
-				report.value && report.value.includes('Endorsed by Admins')
-			);
+			post.endorsedByStaff = reports.some(report => report.value && report.value.includes('Endorsed by Admins'));
 		} catch (err) {
 			post.endorsedByStaff = false;
 		}

--- a/src/api/posts.js
+++ b/src/api/posts.js
@@ -35,6 +35,21 @@ postsAPI.get = async function (caller, data) {
 	Object.assign(post, voted);
 	post.ip = userPrivilege.isAdminOrMod ? post.ip : undefined;
 
+	// Add endorsedByStaff property based on flag reports
+	if (post.flagId) {
+		const flags = require('../flags');
+		try {
+			const reports = await flags.getReports(post.flagId);
+			post.endorsedByStaff = reports.some(report => 
+				report.value && report.value.includes('Endorsed by Admins')
+			);
+		} catch (err) {
+			post.endorsedByStaff = false;
+		}
+	} else {
+		post.endorsedByStaff = false;
+	}
+
 	const selfPost = caller.uid && caller.uid === parseInt(post.uid, 10);
 	if (post.deleted && !(userPrivilege.isAdminOrMod || selfPost)) {
 		post.content = '[[topic:post-is-deleted]]';

--- a/src/search.js
+++ b/src/search.js
@@ -177,12 +177,16 @@ async function filterAndSort(pids, data) {
 }
 
 async function getMatchedPosts(pids, data) {
-	const postFields = ['pid', 'uid', 'tid', 'timestamp', 'deleted', 'upvotes', 'downvotes'];
-
-	let postsData = await posts.getPostsFields(pids, postFields);
+	if (!Array.isArray(pids) || !pids.length) {
+		return [];
+	}
+	const postFields = ['pid', 'uid', 'tid', 'timestamp', 'deleted', 'upvotes', 'downvotes', 'flagId'];
+	let postsData = await posts.getPostsFields(pids.slice(0, 100), postFields);
+	postsData = postsData.filter(Boolean);
 	postsData = postsData.filter(post => post && !post.deleted);
-	const uids = _.uniq(postsData.map(post => post.uid));
-	const tids = _.uniq(postsData.map(post => post.tid));
+
+	const uids = _.uniq(postsData.map(p => p && p.uid));
+	const tids = _.uniq(postsData.map(p => p && p.tid));
 
 	const [users, topics] = await Promise.all([
 		getUsers(uids, data),

--- a/src/topics/posts.js
+++ b/src/topics/posts.js
@@ -1,4 +1,3 @@
-
 'use strict';
 
 const _ = require('lodash');
@@ -130,6 +129,24 @@ module.exports = function (Topics) {
 			Topics.addParentPosts(postData),
 		]);
 
+		// Get flag data for posts with flagId
+		const flaggedPosts = postData.filter(p => p && p.flagId);
+		const flagData = await Promise.all(
+			flaggedPosts.map(async (post) => {
+				try {
+					const reports = await require('../flags').getReports(post.flagId);
+					return { pid: post.pid, reports: reports };
+				} catch (err) {
+					return { pid: post.pid, reports: [] };
+				}
+			})
+		);
+		// Create a map of pid to flag data for quick lookup
+		const flagDataMap = {};
+		flagData.forEach((data) => {
+			flagDataMap[data.pid] = data.reports;
+		});
+
 		postData.forEach((postObj, i) => {
 			if (postObj) {
 				postObj.user = postObj.uid ? userData[postObj.uid] : { ...userData[postObj.uid] };
@@ -140,6 +157,11 @@ module.exports = function (Topics) {
 				postObj.votes = postObj.votes || 0;
 				postObj.replies = replies[i];
 				postObj.selfPost = parseInt(uid, 10) > 0 && parseInt(uid, 10) === postObj.uid;
+
+				// Check if post has a flag with "Endorsed by Admins" report
+				if (flagDataMap[postObj.pid]) {
+					postObj.endorsedByStaff = flagDataMap[postObj.pid].some(report => report.value && report.value.includes('Endorsed by Admins'));
+				}
 
 				// Username override for guests, if enabled
 				if (meta.config.allowGuestHandles && postObj.uid === 0 && postObj.handle) {


### PR DESCRIPTION
- **Frontend Badge for Endorsed by Staff:**
-  This Pull Request adds the frontend component of the new feature @savannahxunc and I have been working on for the past sprint: Allowing staff to endorse posts/replies. @savannahxunc implemented the feature for actually flagging a post, and we spent some time working together to trace the database, and ultimately found data for flags being stored in `db0:flag:#:reports`. After finding this file, I've gone ahead and added javaScript logic to read flag data from the flags database, and display a clean "Endorsed by Staff" badge for comments that have been endorsed by course staff.

- **Files Changed:**
- `src/topics/posts.js` - Added JavaScript logic to check the flags database, and for posts that have a "Endorsed by Admins" value within their respective `db0:flag:#:reports` zset, set the value for true (regarding endorsed or not) within that posts database.
- `nodebb-theme-harmony/templates/partials/topic/post.tpl` - Added conditional rendering in this tpl file to check `posts.endorsedByStaff`, and if this is true, display the badge.

**Video Demo:**

https://github.com/user-attachments/assets/581749ff-ab92-4ae4-b8db-32073053ea6b

**Comments which have been endorsed showing the badge:**
![image](https://github.com/user-attachments/assets/305c39a7-fe6e-4a7d-9057-5236a7eaf49a)

**Database with flag sub sets**
<img width="258" alt="Screenshot 2025-02-25 at 9 34 38 PM" src="https://github.com/user-attachments/assets/3fce1311-7938-4d2b-91fd-0e6488736230" />

**Example of `db0:flag:1:reports`**
<img width="1012" alt="Screenshot 2025-02-25 at 9 34 42 PM" src="https://github.com/user-attachments/assets/03a1b767-7f8e-4a4b-93b9-823a5c30a98d" />

**Issue Resolved Link:** resolves #27 

