### PR TITLE
Add anonymous avatar to anonymous replies

### DIFF
--- a/nodebb-theme-harmony/templates/partials/topic/post.tpl
+++ b/nodebb-theme-harmony/templates/partials/topic/post.tpl
@@ -6,14 +6,16 @@
 </div>
 {{{ end }}}
 <div class="d-flex align-items-start gap-3">
-
-    
 	<div class="bg-body d-none d-sm-block rounded-circle" style="outline: 2px solid var(--bs-body-bg);">
 		<a class="d-inline-block position-relative text-decoration-none" href="{{{ if ./user.userslug }}}{config.relative_path}/user/{./user.userslug}{{{ else }}}#{{{ end }}}" aria-label="[[aria:user-avatar-for, {./user.username}]]">
-			{{{ if !posts.anonymous }}}
+			{{{ if posts.anonymous }}}
+			<div class="avatar avatar-rounded border" style="width: 48px; height: 48px; background-color: #e9ecef; display: flex; align-items: center; justify-content: center;">
+				<i class="fa fa-user-secret fa-2x"></i>
+			</div>
+			{{{ else }}}
 			{buildAvatar(posts.user, "48px", true, "", "user/picture")}
 			<span component="user/status" class="position-absolute translate-middle-y border border-white border-2 rounded-circle status {posts.user.status}"><span class="visually-hidden">[[global:{posts.user.status}]]</span></span>
-		    {{{ end }}}
+			{{{ end }}}
 		</a>
 	</div>
 	
@@ -28,10 +30,14 @@
             
 			<div class="bg-body d-sm-none">
 				<a class="d-inline-block position-relative text-decoration-none" href="{{{ if ./user.userslug }}}{config.relative_path}/user/{./user.userslug}{{{ else }}}#{{{ end }}}">
-					{{{ if !posts.anonymous }}}
+					{{{ if posts.anonymous }}}
+					<div class="avatar avatar-rounded border" style="width: 20px; height: 20px; background-color: #e9ecef; display: flex; align-items: center; justify-content: center;">
+						<i class="fa fa-user-secret"></i>
+					</div>
+					{{{ else }}}
 					{buildAvatar(posts.user, "20px", true, "", "user/picture")}
 					<span component="user/status" class="position-absolute translate-middle-y border border-white border-2 rounded-circle status {posts.user.status}"><span class="visually-hidden">[[global:{posts.user.status}]]</span></span>
-				    {{{ end }}}
+					{{{ end }}}
 				</a>
 			</div>
 			
@@ -39,9 +45,9 @@
 			<!-- changes here -->
 
 			{{{ if posts.anonymous }}}
-			<span>ANONYMOUS</span>
-            {{{ else }}}
-            <a class="fw-bold text-nowrap" href="{{{ if ./user.userslug }}}{config.relative_path}/user/{./user.userslug}{{{ else }}}#{{{ end }}}" data-username="{posts.user.username}" data-uid="{posts.user.uid}">{posts.user.displayname}</a>
+			<span class="fw-bold text-nowrap">Anonymous</span>
+			{{{ else }}}
+			<a class="fw-bold text-nowrap" href="{{{ if ./user.userslug }}}{config.relative_path}/user/{./user.userslug}{{{ else }}}#{{{ end }}}" data-username="{posts.user.username}" data-uid="{posts.user.uid}">{posts.user.displayname}</a>
 			{{{ end }}}
 
 

--- a/nodebb-theme-harmony/templates/partials/topic/quickreply.tpl
+++ b/nodebb-theme-harmony/templates/partials/topic/quickreply.tpl
@@ -17,7 +17,7 @@
 			<div class="d-flex justify-content-end gap-2">
 				<button type="submit" component="topic/quickreply/expand" class="btn-ghost-sm border" title="[[topic:open-composer]]"><i class="fa fa-expand"></i></button>
 				<button type="submit" component="topic/quickreply/button" class="btn btn-sm btn-primary">[[topic:post-quick-reply]]</button>
-				<button type="submit" component="topic/quickreply/button2" class="btn btn-sm btn-primary">[[topic:post-quick-reply2]]</button>
+				<button type="submit" component="topic/quickreply/button2" class="btn btn-sm btn-secondary"><i class="fa fa-user-secret"></i> [[topic:post-quick-reply2]]</button>
 			</div>
 		</div>
 	</form>

--- a/nodebb-theme-harmony/templates/partials/topic/reply-button.tpl
+++ b/nodebb-theme-harmony/templates/partials/topic/reply-button.tpl
@@ -6,7 +6,7 @@
 	</button>
 	<ul class="dropdown-menu dropdown-menu-end p-1 text-sm" role="menu">
 		<li><a class="dropdown-item rounded-1" href="#" component="topic/reply-as-topic" role="menuitem">[[topic:reply-as-topic]]</a></li>
-		<li><a class="dropdown-item rounded-1" href="#" component="topic/reply-as-topic" role="menuitem"> Reply anonymously </a></li>
+		<li><a class="dropdown-item rounded-1" href="#" component="topic/reply-anonymously" role="menuitem">[[topic:reply-anonymously]]</a></li>
 	</ul>
 </div>
 {{{ end }}}

--- a/public/src/client/topic/postTools.js
+++ b/public/src/client/topic/postTools.js
@@ -126,6 +126,18 @@ define('forum/topic/postTools', [
 			});
 		});
 
+		// Add anonymous reply handler
+		$('.topic').on('click', '[component="topic/reply-anonymously"]', function () {
+			showStaleWarning(async function () {
+				hooks.fire('action:composer.post.new', {
+					tid: tid,
+					handle: 1, // Set handle to 1 to mark as anonymous
+					title: ajaxify.data.titleRaw,
+					body: $('[component="topic/quickreply/text"]').val() || '',
+				});
+			});
+		});
+
 		postContainer.on('click', '[component="post/bookmark"]', function () {
 			return bookmarkPost($(this), getData($(this), 'data-pid'));
 		});


### PR DESCRIPTION
**Added an anonymous avatar for anonymous quick replies and styled the anonymous quick reply button**

**Files Changed:**
- `nodebb-theme-harmony/templates/partials/topic/post.tpl`
- **High-level summary:** This .tpl file is responsible for displaying the frontend for each specific reply and post, and reads data from the database to get user information and post content.
- **Modifications:** Edited the existing conditional which rendered the avatar and username when !posts.anonymous to now display the anonymous avatar when posts.anonymous is true. 
- `nodebb-theme-harmony/templates/partials/topic/quickreply.tpl`
- **High-level summary:** This .tpl file is responsible for displaying the frontend of the quick reply button, and posts a reply consisting of the content written in the text box at that time.
- **Modifications:** Edited the styling of the button to be grey to differentiate from the regular quick reply and add the anonymous avatar.

**Video Demo:**

https://github.com/user-attachments/assets/6fd3c1cb-006e-4dc0-a449-10fb6a254b44

**Newly styled anonymous avatar for anonymous quick replies:**
<img width="982" alt="Screenshot 2025-02-26 at 2 08 16 PM" src="https://github.com/user-attachments/assets/cafb4874-200d-4b94-9f19-f20b80eb1c6d" />

**Newly styled anonymous reply button:**
<img width="979" alt="Screenshot 2025-02-26 at 2 08 11 PM" src="https://github.com/user-attachments/assets/926616b5-0c16-4f1a-a8ce-56cff0434763" />

**Issue Link:** resolves #37 
