### PR TITLE
Integrate Flow for Static Analysis (Checkpoint 1)

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,0 +1,14 @@
+[ignore]
+
+[include]
+
+[libs]
+
+[lints]
+untyped-type-import=error
+internal-type=error
+deprecated-type-bool=error
+
+[options]
+
+[strict]

--- a/.flowconfig
+++ b/.flowconfig
@@ -12,5 +12,5 @@ internal-type=error
 deprecated-type-bool=error
 
 [options]
-
+all=true
 [strict]

--- a/.flowconfig
+++ b/.flowconfig
@@ -2,6 +2,8 @@
 
 [include]
 
+src/
+
 [libs]
 
 [lints]

--- a/public/src/client/categories.js
+++ b/public/src/client/categories.js
@@ -1,3 +1,4 @@
+//@flow
 'use strict';
 
 

--- a/public/src/client/categories.js
+++ b/public/src/client/categories.js
@@ -1,4 +1,3 @@
-//@flow
 'use strict';
 
 

--- a/src/batch.js
+++ b/src/batch.js
@@ -1,4 +1,3 @@
-
 'use strict';
 
 const util = require('util');


### PR DESCRIPTION
This PR integrates the static analysis tool "flow" per the requirement in checkpoint 1. 

- Installed Flow as a dev dependency
- Initialized Flow
- Configured .flowconfig to check src/ nad all .js files
- Ran npx flow (artifact shown below)

input: npx flow
output: Launching Flow server for /Users/danielcontreras/Documents/CMU/Spring_25/313/nodebb-s25-information-swimmers
Spawned flow server (pid=4759)
Logs will go to /private/tmp/flow/zSUserszSdanielcontreraszSDocumentszSCMUzSSpring_25zS313zSnodebb-s25-information-swimmers.log
Monitor logs will go to /private/tmp/flow/zSUserszSdanielcontreraszSDocumentszSCMUzSSpring_25zS313zSnodebb-s25-information-swimmers.monitor_log
Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ Gruntfile.js:3:22

Cannot resolve module path. [cannot-resolve-module]

     1│ 'use strict';
     2│
     3│ const path = require('path');
     4│ const nconf = require('nconf');
     5│
     6│ nconf.argv().env({


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ Gruntfile.js:6:7

Cannot call nconf.argv because property argv is missing in exports [1]. [prop-missing]

     Gruntfile.js
     3│ const path = require('path');
     4│ const nconf = require('nconf');
     5│
     6│ nconf.argv().env({
     7│         separator: '__',
     8│ });
     9│ const winston = require('winston');

     node_modules/nconf/lib/nconf.js


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ Gruntfile.js:10:26

Cannot resolve module child_process. [cannot-resolve-module]

      7│        separator: '__',
      8│ });
      9│ const winston = require('winston');
     10│ const { fork } = require('child_process');
     11│
     12│ const { env } = process;
     13│ let worker;


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ Gruntfile.js:12:17

Cannot resolve name process. [cannot-resolve-name]

      9│ const winston = require('winston');
     10│ const { fork } = require('child_process');
     11│
     12│ const { env } = process;
     13│ let worker;
     14│
     15│ env.NODE_ENV = env.NODE_ENV || 'development';


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ Gruntfile.js:17:33

Cannot resolve name __dirname. [cannot-resolve-name]

     14│
     15│ env.NODE_ENV = env.NODE_ENV || 'development';
     16│
     17│ const configFile = path.resolve(__dirname, nconf.any(['config', 'CONFIG']) || 'config.json');
     18│ const prestart = require('./src/prestart');
     19│
     20│ prestart.loadConfig(configFile);


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ Gruntfile.js:17:50

Cannot call nconf.any because property any is missing in exports [1]. [prop-missing]

     Gruntfile.js
     14│
     15│ env.NODE_ENV = env.NODE_ENV || 'development';
     16│
     17│ const configFile = path.resolve(__dirname, nconf.any(['config', 'CONFIG']) || 'config.json');
     18│ const prestart = require('./src/prestart');
     19│
     20│ prestart.loadConfig(configFile);

     node_modules/nconf/lib/nconf.js


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ Gruntfile.js:25:28

Cannot build a typed interface for this module. You should annotate the exports of
this module with types. Missing type annotation at identifier:
[signature-verification-failure]

     22│ const db = require('./src/database');
     23│ const plugins = require('./src/plugins');
     24│
     25│ module.exports = function (grunt) {
     26│        const args = [];
     27│
     28│        if (!grunt.option('verbose')) {


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ Gruntfile.js:30:9

Cannot call nconf.set because property set is missing in exports [1]. [prop-missing]

     Gruntfile.js
     27│
     28│        if (!grunt.option('verbose')) {
     29│                args.push('--log-level=info');
     30│                nconf.set('log-level', 'info');
     31│        }
     32│        prestart.setupWinston();
     33│

     node_modules/nconf/lib/nconf.js


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ Gruntfile.js:42:44

Missing an annotation on implicit this parameter of function. [missing-this-annot]

     39│
     40│        grunt.registerTask('default', ['watch']);
     41│
     42│        grunt.registerTask('init', async function () {
     43│                const done = this.async();
     44│                let pluginList = [];
     45│                if (!process.argv.includes('--core')) {


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ Gruntfile.js:45:8

Cannot resolve name process. [cannot-resolve-name]

     42│        grunt.registerTask('init', async function () {
     43│                const done = this.async();
     44│                let pluginList = [];
     45│                if (!process.argv.includes('--core')) {
     46│                        await db.init();
     47│                        pluginList = await plugins.getActive();
     48│                        addBaseThemes(pluginList);


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ Gruntfile.js:47:31

Cannot call plugins.getActive because property getActive is missing in exports [1].
[prop-missing]

     Gruntfile.js
     44│                let pluginList = [];
     45│                if (!process.argv.includes('--core')) {
     46│                        await db.init();
     47│                        pluginList = await plugins.getActive();
     48│                        addBaseThemes(pluginList);
     49│                        if (!pluginList.includes('nodebb-plugin-composer-default')) {
     50│                                pluginList.push('nodebb-plugin-composer-default');

     src/plugins/index.js


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ Gruntfile.js:139:19

Cannot resolve name process. [cannot-resolve-name]

     136│               }
     137│
     138│               const execArgv = [];
     139│               const inspect = process.argv.find(a => a.startsWith('--inspect'));
     140│
     141│               if (inspect) {
     142│                       execArgv.push(inspect);


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ Gruntfile.js:171:68

Cannot call require(...).build because no more than 2 arguments are expected by async
function [1]. [extra-arg]

     Gruntfile.js
     168│                       return run();
     169│               }
     170│
     171│               require('./src/meta/build').build(compiling, { webpack: false }, (err) => {
     172│                       if (err) {
     173│                               winston.error(err.stack);
     174│                       }
     175│                       if (worker) {
     176│                               worker.send({ compiling: compiling });
     177│                       }
     178│               });
     179│       });
     180│ };
     181│

     src/meta/build.js
 [1] 127│ exports.build = async function (targets, options) {


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ Gruntfile.js:171:69

An annotation on err is required because Flow cannot infer its type from local
context. [missing-local-annot]

     168│                       return run();
     169│               }
     170│
     171│               require('./src/meta/build').build(compiling, { webpack: false }, (err) => {
     172│                       if (err) {
     173│                               winston.error(err.stack);
     174│                       }


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ Gruntfile.js:173:13

Cannot call winston.error because property error is missing in frozen object
literal [1]. [prop-missing]

     Gruntfile.js
     170│
     171│               require('./src/meta/build').build(compiling, { webpack: false }, (err) => {
     172│                       if (err) {
     173│                               winston.error(err.stack);
     174│                       }
     175│                       if (worker) {
     176│                               worker.send({ compiling: compiling });

     node_modules/winston/lib/winston.js


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ Gruntfile.js:182:24

Missing an annotation on pluginList. [missing-local-annot]

     179│       });
     180│ };
     181│
     182│ function addBaseThemes(pluginList) {
     183│       let themeId = pluginList.find(p => p.includes('nodebb-theme-'));
     184│       if (!themeId) {
     185│               return pluginList;


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ Gruntfile.js:190:16

The parameter passed to require must be a string literal. [unsupported-syntax]

     187│       let baseTheme;
     188│       do {
     189│               try {
     190│                       baseTheme = require(`${themeId}/theme`).baseTheme;
     191│               } catch (err) {
     192│                       console.log(err);
     193│               }


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ app.js:26:7

Cannot call nconf.argv because property argv is missing in exports [1]. [prop-missing]

     app.js
     23│
     24│ const nconf = require('nconf');
     25│
     26│ nconf.argv().env({
     27│        separator: '__',
     28│ });
     29│

     node_modules/nconf/lib/nconf.js


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ app.js:31:22

Cannot resolve module path. [cannot-resolve-module]

     28│ });
     29│
     30│ const winston = require('winston');
     31│ const path = require('path');
     32│
     33│ const file = require('./src/file');
     34│


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ app.js:35:1

Cannot resolve name process. [cannot-resolve-name]

     32│
     33│ const file = require('./src/file');
     34│
     35│ process.env.NODE_ENV = process.env.NODE_ENV || 'production';
     36│ global.env = process.env.NODE_ENV || 'production';
     37│
     38│ // Alternate configuration file support


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ app.js:35:24

Cannot resolve name process. [cannot-resolve-name]

     32│
     33│ const file = require('./src/file');
     34│
     35│ process.env.NODE_ENV = process.env.NODE_ENV || 'production';
     36│ global.env = process.env.NODE_ENV || 'production';
     37│
     38│ // Alternate configuration file support


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ app.js:36:14

Cannot resolve name process. [cannot-resolve-name]

     33│ const file = require('./src/file');
     34│
     35│ process.env.NODE_ENV = process.env.NODE_ENV || 'production';
     36│ global.env = process.env.NODE_ENV || 'production';
     37│
     38│ // Alternate configuration file support
     39│ const configFile = path.resolve(__dirname, nconf.any(['config', 'CONFIG']) || 'config.json');


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ app.js:39:33

Cannot resolve name __dirname. [cannot-resolve-name]

     36│ global.env = process.env.NODE_ENV || 'production';
     37│
     38│ // Alternate configuration file support
     39│ const configFile = path.resolve(__dirname, nconf.any(['config', 'CONFIG']) || 'config.json');
     40│
     41│ const configExists = file.existsSync(configFile) || (nconf.get('url') && nconf.get('secret') && nconf.get('database'));
     42│


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ app.js:39:50

Cannot call nconf.any because property any is missing in exports [1]. [prop-missing]

     app.js
     36│ global.env = process.env.NODE_ENV || 'production';
     37│
     38│ // Alternate configuration file support
     39│ const configFile = path.resolve(__dirname, nconf.any(['config', 'CONFIG']) || 'config.json');
     40│
     41│ const configExists = file.existsSync(configFile) || (nconf.get('url') && nconf.get('secret') && nconf.get('database'));
     42│

     node_modules/nconf/lib/nconf.js


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ app.js:41:27

Cannot call file.existsSync because property existsSync is missing in exports [1].
[prop-missing]

     app.js
     38│ // Alternate configuration file support
     39│ const configFile = path.resolve(__dirname, nconf.any(['config', 'CONFIG']) || 'config.json');
     40│
     41│ const configExists = file.existsSync(configFile) || (nconf.get('url') && nconf.get('secret') && nconf.get('database'));
     42│
     43│ const prestart = require('./src/prestart');
     44│

     src/file.js


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ app.js:41:60

Cannot get nconf.get because property get is missing in exports [1]. [prop-missing]

     app.js
     38│ // Alternate configuration file support
     39│ const configFile = path.resolve(__dirname, nconf.any(['config', 'CONFIG']) || 'config.json');
     40│
     41│ const configExists = file.existsSync(configFile) || (nconf.get('url') && nconf.get('secret') && nconf.get('database'));
     42│
     43│ const prestart = require('./src/prestart');
     44│

     node_modules/nconf/lib/nconf.js


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ app.js:41:60

Cannot call nconf.get because property get is missing in exports [1]. [prop-missing]

     app.js
     38│ // Alternate configuration file support
     39│ const configFile = path.resolve(__dirname, nconf.any(['config', 'CONFIG']) || 'config.json');
     40│
     41│ const configExists = file.existsSync(configFile) || (nconf.get('url') && nconf.get('secret') && nconf.get('database'));
     42│
     43│ const prestart = require('./src/prestart');
     44│

     node_modules/nconf/lib/nconf.js


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ app.js:41:80

Cannot get nconf.get because property get is missing in exports [1]. [prop-missing]

     app.js
     38│ // Alternate configuration file support
     39│ const configFile = path.resolve(__dirname, nconf.any(['config', 'CONFIG']) || 'config.json');
     40│
     41│ const configExists = file.existsSync(configFile) || (nconf.get('url') && nconf.get('secret') && nconf.get('database'));
     42│
     43│ const prestart = require('./src/prestart');
     44│

     node_modules/nconf/lib/nconf.js


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ app.js:41:80

Cannot call nconf.get because property get is missing in exports [1]. [prop-missing]

     app.js
     38│ // Alternate configuration file support
     39│ const configFile = path.resolve(__dirname, nconf.any(['config', 'CONFIG']) || 'config.json');
     40│
     41│ const configExists = file.existsSync(configFile) || (nconf.get('url') && nconf.get('secret') && nconf.get('database'));
     42│
     43│ const prestart = require('./src/prestart');
     44│

     node_modules/nconf/lib/nconf.js


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ app.js:41:103

Cannot call nconf.get because property get is missing in exports [1]. [prop-missing]

     app.js
     38│ // Alternate configuration file support
     39│ const configFile = path.resolve(__dirname, nconf.any(['config', 'CONFIG']) || 'config.json');
     40│
     41│ const configExists = file.existsSync(configFile) || (nconf.get('url') && nconf.get('secret') && nconf.get('database'));
     42│
     43│ const prestart = require('./src/prestart');
     44│

     node_modules/nconf/lib/nconf.js


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ app.js:48:9

Cannot call winston.verbose because property verbose is missing in frozen object
literal [1]. [prop-missing]

     app.js
     45│ prestart.loadConfig(configFile);
     46│ prestart.setupWinston();
     47│ prestart.versionCheck();
     48│ winston.verbose('* using configuration stored in: %s', configFile);
     49│
     50│ if (!process.send) {
     51│        // If run using `node app`, log GNU copyright info along with server info

     node_modules/winston/lib/winston.js


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ app.js:50:6

Cannot resolve name process. [cannot-resolve-name]

     47│ prestart.versionCheck();
     48│ winston.verbose('* using configuration stored in: %s', configFile);
     49│
     50│ if (!process.send) {
     51│        // If run using `node app`, log GNU copyright info along with server info
     52│        winston.info(`NodeBB v${nconf.get('version')} Copyright (C) 2013-${(new Date()).getFullYear()} NodeBB Inc.`);
     53│        winston.info('This program comes with ABSOLUTELY NO WARRANTY.');


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ app.js:52:10

Cannot call winston.info because property info is missing in frozen object
literal [1]. [prop-missing]

     app.js
     49│
     50│ if (!process.send) {
     51│        // If run using `node app`, log GNU copyright info along with server info
     52│        winston.info(`NodeBB v${nconf.get('version')} Copyright (C) 2013-${(new Date()).getFullYear()} NodeBB Inc.`);
     53│        winston.info('This program comes with ABSOLUTELY NO WARRANTY.');
     54│        winston.info('This is free software, and you are welcome to redistribute it under certain conditions.');
     55│        winston.info('');

     node_modules/winston/lib/winston.js


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ app.js:52:32

Cannot call nconf.get because property get is missing in exports [1]. [prop-missing]

     app.js
     49│
     50│ if (!process.send) {
     51│        // If run using `node app`, log GNU copyright info along with server info
     52│        winston.info(`NodeBB v${nconf.get('version')} Copyright (C) 2013-${(new Date()).getFullYear()} NodeBB Inc.`);
     53│        winston.info('This program comes with ABSOLUTELY NO WARRANTY.');
     54│        winston.info('This is free software, and you are welcome to redistribute it under certain conditions.');
     55│        winston.info('');

     node_modules/nconf/lib/nconf.js


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ app.js:53:10

Cannot call winston.info because property info is missing in frozen object
literal [1]. [prop-missing]

     app.js
     50│ if (!process.send) {
     51│        // If run using `node app`, log GNU copyright info along with server info
     52│        winston.info(`NodeBB v${nconf.get('version')} Copyright (C) 2013-${(new Date()).getFullYear()} NodeBB Inc.`);
     53│        winston.info('This program comes with ABSOLUTELY NO WARRANTY.');
     54│        winston.info('This is free software, and you are welcome to redistribute it under certain conditions.');
     55│        winston.info('');
     56│ }

     node_modules/winston/lib/winston.js


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ app.js:54:10

Cannot call winston.info because property info is missing in frozen object
literal [1]. [prop-missing]

     app.js
     51│        // If run using `node app`, log GNU copyright info along with server info
     52│        winston.info(`NodeBB v${nconf.get('version')} Copyright (C) 2013-${(new Date()).getFullYear()} NodeBB Inc.`);
     53│        winston.info('This program comes with ABSOLUTELY NO WARRANTY.');
     54│        winston.info('This is free software, and you are welcome to redistribute it under certain conditions.');
     55│        winston.info('');
     56│ }
     57│

     node_modules/winston/lib/winston.js


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ app.js:55:10

Cannot call winston.info because property info is missing in frozen object
literal [1]. [prop-missing]

     app.js
     52│        winston.info(`NodeBB v${nconf.get('version')} Copyright (C) 2013-${(new Date()).getFullYear()} NodeBB Inc.`);
     53│        winston.info('This program comes with ABSOLUTELY NO WARRANTY.');
     54│        winston.info('This is free software, and you are welcome to redistribute it under certain conditions.');
     55│        winston.info('');
     56│ }
     57│
     58│ if (nconf.get('setup') || nconf.get('install')) {

     node_modules/winston/lib/winston.js


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ app.js:58:11

Cannot get nconf.get because property get is missing in exports [1]. [prop-missing]

     app.js
     55│        winston.info('');
     56│ }
     57│
     58│ if (nconf.get('setup') || nconf.get('install')) {
     59│        require('./src/cli/setup').setup();
     60│ } else if (!configExists) {
     61│        require('./install/web').install(nconf.get('port'));

     node_modules/nconf/lib/nconf.js


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ app.js:58:11

Cannot call nconf.get because property get is missing in exports [1]. [prop-missing]

     app.js
     55│        winston.info('');
     56│ }
     57│
     58│ if (nconf.get('setup') || nconf.get('install')) {
     59│        require('./src/cli/setup').setup();
     60│ } else if (!configExists) {
     61│        require('./install/web').install(nconf.get('port'));

     node_modules/nconf/lib/nconf.js


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ app.js:58:33

Cannot get nconf.get because property get is missing in exports [1]. [prop-missing]

     app.js
     55│        winston.info('');
     56│ }
     57│
     58│ if (nconf.get('setup') || nconf.get('install')) {
     59│        require('./src/cli/setup').setup();
     60│ } else if (!configExists) {
     61│        require('./install/web').install(nconf.get('port'));

     node_modules/nconf/lib/nconf.js


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ app.js:58:33

Cannot call nconf.get because property get is missing in exports [1]. [prop-missing]

     app.js
     55│        winston.info('');
     56│ }
     57│
     58│ if (nconf.get('setup') || nconf.get('install')) {
     59│        require('./src/cli/setup').setup();
     60│ } else if (!configExists) {
     61│        require('./install/web').install(nconf.get('port'));

     node_modules/nconf/lib/nconf.js


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ app.js:61:27

Cannot call require(...).install because property install is missing in exports [1].
[prop-missing]

     app.js
     58│ if (nconf.get('setup') || nconf.get('install')) {
     59│        require('./src/cli/setup').setup();
     60│ } else if (!configExists) {
     61│        require('./install/web').install(nconf.get('port'));
     62│ } else if (nconf.get('upgrade')) {
     63│        require('./src/cli/upgrade').upgrade(true);
     64│ } else if (nconf.get('reset')) {

     install/web.js


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ app.js:61:41

Cannot call nconf.get because property get is missing in exports [1]. [prop-missing]

     app.js
     58│ if (nconf.get('setup') || nconf.get('install')) {
     59│        require('./src/cli/setup').setup();
     60│ } else if (!configExists) {
     61│        require('./install/web').install(nconf.get('port'));
     62│ } else if (nconf.get('upgrade')) {
     63│        require('./src/cli/upgrade').upgrade(true);
     64│ } else if (nconf.get('reset')) {

     node_modules/nconf/lib/nconf.js


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ app.js:62:18

Cannot get nconf.get because property get is missing in exports [1]. [prop-missing]

     app.js
     59│        require('./src/cli/setup').setup();
     60│ } else if (!configExists) {
     61│        require('./install/web').install(nconf.get('port'));
     62│ } else if (nconf.get('upgrade')) {
     63│        require('./src/cli/upgrade').upgrade(true);
     64│ } else if (nconf.get('reset')) {
     65│        require('./src/cli/reset').reset({

     node_modules/nconf/lib/nconf.js


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ app.js:62:18

Cannot call nconf.get because property get is missing in exports [1]. [prop-missing]

     app.js
     59│        require('./src/cli/setup').setup();
     60│ } else if (!configExists) {
     61│        require('./install/web').install(nconf.get('port'));
     62│ } else if (nconf.get('upgrade')) {
     63│        require('./src/cli/upgrade').upgrade(true);
     64│ } else if (nconf.get('reset')) {
     65│        require('./src/cli/reset').reset({

     node_modules/nconf/lib/nconf.js


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ app.js:64:18

Cannot get nconf.get because property get is missing in exports [1]. [prop-missing]

     app.js
     61│        require('./install/web').install(nconf.get('port'));
     62│ } else if (nconf.get('upgrade')) {
     63│        require('./src/cli/upgrade').upgrade(true);
     64│ } else if (nconf.get('reset')) {
     65│        require('./src/cli/reset').reset({
     66│                theme: nconf.get('t'),
     67│                plugin: nconf.get('p'),

     node_modules/nconf/lib/nconf.js


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ app.js:64:18

Cannot call nconf.get because property get is missing in exports [1]. [prop-missing]

     app.js
     61│        require('./install/web').install(nconf.get('port'));
     62│ } else if (nconf.get('upgrade')) {
     63│        require('./src/cli/upgrade').upgrade(true);
     64│ } else if (nconf.get('reset')) {
     65│        require('./src/cli/reset').reset({
     66│                theme: nconf.get('t'),
     67│                plugin: nconf.get('p'),

     node_modules/nconf/lib/nconf.js


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ app.js:66:16

Cannot call nconf.get because property get is missing in exports [1]. [prop-missing]

     app.js
     63│        require('./src/cli/upgrade').upgrade(true);
     64│ } else if (nconf.get('reset')) {
     65│        require('./src/cli/reset').reset({
     66│                theme: nconf.get('t'),
     67│                plugin: nconf.get('p'),
     68│                widgets: nconf.get('w'),
     69│                settings: nconf.get('s'),

     node_modules/nconf/lib/nconf.js


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ app.js:67:17

Cannot call nconf.get because property get is missing in exports [1]. [prop-missing]

     app.js
     64│ } else if (nconf.get('reset')) {
     65│        require('./src/cli/reset').reset({
     66│                theme: nconf.get('t'),
     67│                plugin: nconf.get('p'),
     68│                widgets: nconf.get('w'),
     69│                settings: nconf.get('s'),
     70│                all: nconf.get('a'),

     node_modules/nconf/lib/nconf.js


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ app.js:68:18

Cannot call nconf.get because property get is missing in exports [1]. [prop-missing]

     app.js
     65│        require('./src/cli/reset').reset({
     66│                theme: nconf.get('t'),
     67│                plugin: nconf.get('p'),
     68│                widgets: nconf.get('w'),
     69│                settings: nconf.get('s'),
     70│                all: nconf.get('a'),
     71│        });

     node_modules/nconf/lib/nconf.js



... 44116 more errors (only 50 out of 44166 errors displayed)
To see all errors, re-run Flow with --show-all-errors

